### PR TITLE
Make the wiki link better

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -6,7 +6,7 @@
         {% for p in nav_pages %}
           {% if p.title %}
 					<li>
-						<a class="page-link{% if p.top_url == page.top_url %} active{% endif %}" href="{{ p.top_url | prepend: site.baseurl }}">
+						<a class="page-link{% if p.top_url == page.top_url %} active{% endif %}" href="{% if p.menu_link_url %}{{ p.menu_link_url }}{% else %}{{ p.top_url | prepend: site.baseurl }}{% endif %}">
 							{{ p.title }}
 						</a>
 						{% if p.sub_menu %}

--- a/pages/wiki.html
+++ b/pages/wiki.html
@@ -2,11 +2,11 @@
 title: Wiki
 permalink: /wiki/
 top_url: /wiki/
+menu_link_url: https://wiki.darmstadt.freifunk.net/
 main_menu: true
 weight: 6
 layout: base
 hide_footer: true
 ---
-<iframe src="https://wiki.darmstadt.freifunk.net"
-  width="100%" style="display:block; height: calc(100vh - 3.25em);width: 100%;">
-</iframe>
+Unsere Plenumsprotokolle und viele weitere Informationen findest du in unserem <a href="https://wiki.darmstadt.freifunk.net">Wiki</a>.
+


### PR DESCRIPTION
Der Wiki-Link funktioniert nur so mitteltoll, denn das Wiki wird in einem Iframe geladen. Das Wiki möchte aber sein Login-Formular nicht so gerne in einem Iframe angezeigt haben, deshalb sendet es ein X-Frame-Options: SAMEORIGIN mit. Also sieht man nur eine leere Seite, wenn man "Anmelden" klickt.

Dieser Pullrequest sorgt dafür, dass das im Menü ein Direktlink aufs Wiki ist, sodass es nicht mehr in einem Iframe erscheint.